### PR TITLE
Plywood detail panel

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1759,6 +1759,7 @@
         "anymatch": "2.0.0",
         "async-each": "1.0.3",
         "braces": "2.3.2",
+        "fsevents": "1.2.9",
         "glob-parent": "3.1.0",
         "inherits": "2.0.4",
         "is-binary-path": "1.0.1",
@@ -3663,6 +3664,535 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.14.0",
+        "node-pre-gyp": "0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.3.5"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.3.5"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "4.1.1",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.3.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.4.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.6.3",
+            "semver": "5.7.0",
+            "tar": "4.4.8"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.6"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.1.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.12",

--- a/frontend/src/components/app.tsx
+++ b/frontend/src/components/app.tsx
@@ -4,7 +4,7 @@ import { extractSinks } from 'cyclejs-utils';
 import isolate from '@cycle/isolate';
 
 import { driverNames } from '../drivers';
-import { Sources, Sinks, Reducer, Component } from '../interfaces';
+import { Sources, Sinks, Reducer, Component, Command } from '../interfaces';
 
 import { MapSearch, State as MapSearchState } from './map-search';
 import { Building, State as BuildingState } from './building';
@@ -12,6 +12,7 @@ import {
     RawMaterialMap,
     State as RawMaterialMapState
 } from './raw-material-map';
+import { Dictionary } from 'ramda';
 
 export interface State {
     mapSearch?: MapSearchState;
@@ -24,7 +25,7 @@ export function App(sources: Sources<State>): Sinks<State> {
     sources.commandGateway = commandGateway$;
 
     const match$ = sources.router.define({
-        '/map-search': isolate(MapSearch, 'map-search'),
+        '/browse-building': isolate(MapSearch, 'map-search'),
         '/building/:id': (props: any) =>
             isolate(Building.bind(undefined, props), 'building'),
         '/raw-material-map': isolate(RawMaterialMap, 'raw-material-map')
@@ -32,7 +33,7 @@ export function App(sources: Sources<State>): Sinks<State> {
 
     const layout$ = sources.router
         .define({
-            '/map-search': { map: true, building: false },
+            '/browse-building': { map: true, building: false },
             '/building/:id': { map: false, building: true },
             '/raw-material-map': { map: true, building: false }
         })
@@ -49,16 +50,20 @@ export function App(sources: Sources<State>): Sinks<State> {
 
     const redirect$: Stream<string> = sources.router.history$
         .filter((l: Location) => l.pathname === '/')
-        .mapTo('/map-search');
+        .mapTo('/browse-building');
 
     // Ensure that first page loads are routed and rendered correctly
     const firstTimePageLoad$: Stream<string> = sources.router.history$
         .filter((l: any) => l.pathname !== '/' && l.type === undefined)
         .map((l: Location) => l.pathname);
 
+    const navigateTo: Dictionary<string> = {
+        'navigate-to-building-browser': '/browse-building',
+        'show-asset-origin': '/raw-material-map'
+    };
     const handledNavigateEvents$ = commandGateway$
-        .filter(cmd => cmd.type === 'navigate-to-building-browser')
-        .mapTo('/map-search');
+        .map((cmd: Command) => navigateTo[cmd.type])
+        .filter(path => path !== undefined);
 
     const sinks = extractSinks(componentSinks$, driverNames);
 

--- a/frontend/src/components/building.tsx
+++ b/frontend/src/components/building.tsx
@@ -18,23 +18,26 @@ export const defaultState: State = {
 interface DOMIntent {
     link$: Stream<null>;
     building$: Stream<any>;
+    dispatch$: Stream<any>;
 }
 
 export function Building(props: any, sources: Sources<State>): Sinks<State> {
     console.log('Building', sources);
     const { DOM, state, router, dataQuery }: Sources<State> = sources;
     const props$ = xs.of(props);
-    const { link$, building$ }: DOMIntent = intent(DOM, props$);
+    const { link$, building$, dispatch$ }: DOMIntent = intent(DOM, props$);
+
     return {
-        DOM: view(state.stream),
+        DOM: view(state.stream, dispatch$),
         state: model(building$, dataQuery),
         router: redirect(link$),
-        dataQuery: query(building$)
+        dataQuery: query(building$, dispatch$)
     };
 }
 
-function query(building$: Stream<string>): Stream<any> {
-    return building$.map(id => ({ type: 'buildings', id }));
+function query(building$: Stream<string>, dispatch$: Stream<any>): Stream<any> {
+    const buildingQuery$ = building$.map(id => ({ type: 'buildings', id }));
+    return xs.merge(buildingQuery$, dispatch$);
 }
 
 function model(
@@ -51,14 +54,18 @@ function model(
         .map(buildingId => ({ buildingId }))
         .map(addToState);
 
-    const buildingDetails$ = dataQuery.map(data =>
-        addToState({ buildingDetails: data })
-    );
+    const buildingDetails$ = dataQuery
+        .filter(res => res.req.type === 'buildings')
+        .map(data => addToState({ buildingDetails: data }));
 
-    return xs.merge(init$, buildingId$, buildingDetails$);
+    const plywoodDetails$ = dataQuery
+        .filter(res => res.req.type === 'plywood')
+        .map(data => addToState({ plywoodDetails: data }));
+
+    return xs.merge(init$, buildingId$, buildingDetails$, plywoodDetails$);
 }
 
-function view(state$: Stream<State>): Stream<VNode> {
+function view(state$: Stream<State>, dispatch$: Stream<any>): Stream<VNode> {
     const renderDetails = (rows: any[]) => {
         return (
             <div className="asset-table">
@@ -72,13 +79,22 @@ function view(state$: Stream<State>): Stream<VNode> {
                         </tr>
                     </thead>
                     <tbody>
-                        {rows.map((row: any) => (
-                            <tr data-action="navigate">
-                                <td>{row.type}</td>
-                                <td>{row.id}</td>
-                                <td>{row.producer}</td>
-                            </tr>
-                        ))}
+                        {rows.map((row: any) => {
+                            return (
+                                <tr
+                                    onclick={() =>
+                                        dispatch$.shamefullySendNext({
+                                            type: row.type,
+                                            id: row.id
+                                        })
+                                    }
+                                >
+                                    <td>{row.type}</td>
+                                    <td>{row.id}</td>
+                                    <td>{row.producer}</td>
+                                </tr>
+                            );
+                        })}
                     </tbody>
                 </table>
             </div>
@@ -90,6 +106,7 @@ function view(state$: Stream<State>): Stream<VNode> {
             <div className="building-details">
                 <h2>Building details</h2>
                 <p>Building id: {state.buildingId}</p>
+                <p>State: {JSON.stringify(state)}</p>
                 {state.buildingDetails ? '' : <p>Loading...</p>}
                 {state.buildingDetails && state.buildingDetails.found ? (
                     renderDetails(state.buildingDetails.data)
@@ -102,6 +119,8 @@ function view(state$: Stream<State>): Stream<VNode> {
 }
 
 function intent(DOM: DOMSource, props: Stream<any>): DOMIntent {
+    const dispatch$ = xs.never();
+
     const link$ = DOM.select('[data-action="navigate"]')
         .events('click')
         .mapTo(null);
@@ -110,7 +129,7 @@ function intent(DOM: DOMSource, props: Stream<any>): DOMIntent {
     const building$ = props.map((data: any) => {
         return data;
     });
-    return { link$, building$ };
+    return { link$, building$, dispatch$ };
 }
 
 function redirect(link$: Stream<any>): Stream<string> {

--- a/frontend/src/components/building.tsx
+++ b/frontend/src/components/building.tsx
@@ -73,6 +73,7 @@ function model(
     const assetDetails$ = dataQuery
         .filter(res => res.req.type === 'plywood')
         .map(data => addToState({ assetDetails: data }));
+
     const resetBuildingAssets$ = commandGateway$
         .filter(cmd => cmd.type === 'reset-building-assets')
         .map(state => addToState({ assetDetails: undefined }));
@@ -95,7 +96,20 @@ const renderBuildingDetails = (props: RenderBuildingDetailsProps) => {
     return (
         <div>
             <div id="building-details" className="asset-table">
-                <div className="header">Building (id: {props.id})</div>
+                <div className="header">
+                    <button
+                        onclick={(e: any) => {
+                            console.log('navigate-to-building-browser');
+                            e.preventDefault();
+                            props.dispatchFn({
+                                type: 'navigate-to-building-browser'
+                            });
+                        }}
+                    >
+                        Back to map
+                    </button>
+                    Building (id: {props.id})
+                </div>
                 <table>
                     <thead>
                         <tr>
@@ -108,6 +122,7 @@ const renderBuildingDetails = (props: RenderBuildingDetailsProps) => {
                         {props.rows.map((row: any) => {
                             return (
                                 <tr
+                                    id={`asset-${row.type}-id-${row.id}`}
                                     onclick={(e: any) => {
                                         console.log('show-building-assets');
                                         e.preventDefault();
@@ -258,9 +273,8 @@ function view(
 function intent(
     DOM: DOMSource,
     props: Stream<any>,
-    commandGateway: Stream<any>
+    commandGateway: Stream<Command>
 ): DOMIntent {
-    const commandGateway$ = commandGateway || xs.never();
     const link$ = xs.never();
     // DOM.select('[data-action="navigate"]')
     //     .events('click')
@@ -270,7 +284,7 @@ function intent(
     const building$ = props.map((data: any) => {
         return data;
     });
-    return { link$, building$, commandGateway$ };
+    return { link$, building$, commandGateway$: commandGateway };
 }
 
 function redirect(link$: Stream<any>): Stream<string> {

--- a/frontend/src/components/building.tsx
+++ b/frontend/src/components/building.tsx
@@ -155,7 +155,7 @@ interface RenderAssetDetailsProps {
 }
 const renderAssetDetails = (props: RenderAssetDetailsProps) => {
     return (
-        <div id="asset-details" className="asset-detail">
+        <div id="asset-details" className="asset-table">
             <div className="header">
                 <button
                     onclick={(e: any) => {

--- a/frontend/src/components/building.tsx
+++ b/frontend/src/components/building.tsx
@@ -99,7 +99,6 @@ const renderBuildingDetails = (props: RenderBuildingDetailsProps) => {
                 <div className="header">
                     <button
                         onclick={(e: any) => {
-                            console.log('navigate-to-building-browser');
                             e.preventDefault();
                             props.dispatchFn({
                                 type: 'navigate-to-building-browser'
@@ -124,7 +123,6 @@ const renderBuildingDetails = (props: RenderBuildingDetailsProps) => {
                                 <tr
                                     id={`asset-${row.type}-id-${row.id}`}
                                     onclick={(e: any) => {
-                                        console.log('show-building-assets');
                                         e.preventDefault();
                                         props.dispatchFn({
                                             type: 'show-building-assets',
@@ -159,7 +157,6 @@ const renderAssetDetails = (props: RenderAssetDetailsProps) => {
             <div className="header">
                 <button
                     onclick={(e: any) => {
-                        console.log('reset-building-assets');
                         e.preventDefault();
                         props.dispatchFn({ type: 'reset-building-assets' });
                     }}
@@ -186,7 +183,6 @@ const renderAssetDetails = (props: RenderAssetDetailsProps) => {
                                         data: { dataType: row.type },
                                         id: row.id
                                     };
-                                    console.log('show-asset-origin', cmd);
                                     e.preventDefault();
                                     props.dispatchFn(cmd);
                                 }}
@@ -254,8 +250,6 @@ function view(
     return state$.map((state: State) => {
         return (
             <div className="building-details">
-                <h2>Building details</h2>
-                <p>State: {JSON.stringify(state)}</p>
                 {renderDetailsPanels({
                     buildingDetailsFound:
                         state.buildingDetails && state.buildingDetails.found,

--- a/frontend/src/drivers.ts
+++ b/frontend/src/drivers.ts
@@ -5,6 +5,7 @@ import { routerify } from 'cyclic-router';
 import switchPath from 'switch-path';
 import { layoutDriver } from './drivers/layoutDriver';
 import { dataQueryDriver } from './drivers/dataQueryDriver';
+import { mapDriver } from './drivers/mapDriver';
 
 import { Component } from './interfaces';
 
@@ -12,7 +13,8 @@ const driversFactories: any = {
     DOM: () => makeDOMDriver('#app'),
     history: () => makeHistoryDriver(),
     layout: () => layoutDriver,
-    dataQuery: () => dataQueryDriver
+    dataQuery: () => dataQueryDriver,
+    map: () => mapDriver
 };
 
 export function getDrivers(): any {

--- a/frontend/src/drivers/dataQueryDriver.ts
+++ b/frontend/src/drivers/dataQueryDriver.ts
@@ -25,6 +25,14 @@ const data: Data = {
             { type: 'plywood', id: 'p124', producer: 'UPM Plywood' },
             { type: 'plywood', id: 'p125', producer: 'UPM Plywood' }
         ]
+    },
+    plywood: {
+        p123: [
+            { type: 'tree-trunk', id: 'p123-1', coords: [123.11, 1234.11] },
+            { type: 'tree-trunk', id: 'p123-2', coords: [123.22, 1234.22] }
+        ],
+        p124: [{ type: 'tree-trunk', id: '123', coords: [234.11, 234.11] }],
+        p125: [{ type: 'tree-trunk', id: '123', coords: [32.11, 3423.22] }]
     }
 };
 

--- a/frontend/src/drivers/dataQueryDriver.ts
+++ b/frontend/src/drivers/dataQueryDriver.ts
@@ -31,8 +31,8 @@ const data: Data = {
             { type: 'tree-trunk', id: 'p123-1', coords: [123.11, 1234.11] },
             { type: 'tree-trunk', id: 'p123-2', coords: [123.22, 1234.22] }
         ],
-        p124: [{ type: 'tree-trunk', id: '123', coords: [234.11, 234.11] }],
-        p125: [{ type: 'tree-trunk', id: '123', coords: [32.11, 3423.22] }]
+        p124: [{ type: 'tree-trunk', id: 'p124-1', coords: [234.11, 234.11] }],
+        p125: [{ type: 'tree-trunk', id: 'p125-1', coords: [32.11, 3423.22] }]
     }
 };
 

--- a/frontend/src/drivers/mapDriver.ts
+++ b/frontend/src/drivers/mapDriver.ts
@@ -1,0 +1,20 @@
+import { Command, MapEventData } from './../interfaces';
+import { Stream } from 'xstream';
+
+const eventRoot = document.body;
+
+eventRoot.addEventListener('map-event', e =>
+    console.log('CUSTOM EVENTS: map-event', e)
+);
+
+export function mapDriver(map$: Stream<Command<MapEventData[]>>): void {
+    map$.addListener({
+        next: (mapCommand: Command<MapEventData[]>) => {
+            console.log('jee jee');
+            const e = new CustomEvent<MapEventData[]>('map-event', {
+                detail: mapCommand.data
+            });
+            eventRoot.dispatchEvent(e);
+        }
+    });
+}

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -8,11 +8,18 @@ export { Reducer } from '@cycle/state';
 
 export type Component<State> = (s: Sources<State>) => Sinks<State>;
 
+export type Command = {
+    type: 'show-building' | 'show-building-assets' | 'reset-building-assets';
+    id?: string;
+    data?: any;
+};
+
 export interface Sources<State> {
     DOM: DOMSource;
     router: RouterSource;
     state: StateSource<State>;
     dataQuery: Stream<any>;
+    commandGateway: Stream<Command>;
 }
 
 export interface Sinks<State> {
@@ -22,4 +29,5 @@ export interface Sinks<State> {
     layout?: Stream<LayoutState>;
     state?: Stream<Reducer<State>>;
     dataQuery?: Stream<{ type: string; id: string }>;
+    commandGateway?: Stream<any>;
 }

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -9,7 +9,11 @@ export { Reducer } from '@cycle/state';
 export type Component<State> = (s: Sources<State>) => Sinks<State>;
 
 export type Command = {
-    type: 'show-building' | 'show-building-assets' | 'reset-building-assets';
+    type:
+        | 'show-building'
+        | 'show-building-assets'
+        | 'reset-building-assets'
+        | 'show-asset-origin';
     id?: string;
     data?: any;
 };

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -8,7 +8,7 @@ export { Reducer } from '@cycle/state';
 
 export type Component<State> = (s: Sources<State>) => Sinks<State>;
 
-export type Command = {
+export type Command<T = any> = {
     type:
         | 'show-building'
         | 'show-building-assets'
@@ -16,7 +16,12 @@ export type Command = {
         | 'show-asset-origin'
         | 'navigate-to-building-browser';
     id?: string;
-    data?: any;
+    data?: T;
+};
+
+export type MapEventData = {
+    type: 'ensure-tree' | 'move-to';
+    coords: { x: number; y: number };
 };
 
 export interface Sources<State> {
@@ -35,4 +40,5 @@ export interface Sinks<State> {
     state?: Stream<Reducer<State>>;
     dataQuery?: Stream<{ type: string; id: string }>;
     commandGateway?: Stream<any>;
+    map?: Stream<Command<MapEventData[]>>;
 }

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -13,7 +13,8 @@ export type Command = {
         | 'show-building'
         | 'show-building-assets'
         | 'reset-building-assets'
-        | 'show-asset-origin';
+        | 'show-asset-origin'
+        | 'navigate-to-building-browser';
     id?: string;
     data?: any;
 };


### PR DESCRIPTION
Implements asset detail panel where plywood details (individual tree trunks) are shown.
User can view the tree trunks by clicking a plywood row in the building table.

User can return to:
* building asset table by pressing a back button in the detail panel
* to the browse buildings map by pressing back button in the building table

Building view dispatches a custom event with coordinates when a tree trunk row is clicked in the detail panel. 

Todo:
* Currently the coordinates are placeholders for real values
* Map does not act on the event yet